### PR TITLE
fix(nix): add Dependabot for flake.lock updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Renovate's nix manager cannot update flake.lock on Mend-hosted infrastructure:
+  # it requires running `nix flake update` (to compute narHash values), but the
+  # sandboxed jr-microvm environment has no nix binary and allowedCommands is locked
+  # to git add/reset/pwd only. Every Monday run ends with "Digest is not updated" →
+  # level-40 "Error updating branch: update failure". Dependabot handles flake.lock
+  # instead; the nix manager is disabled in renovate.json.
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+      timezone: "UTC"
+    groups:
+      nix-flake-inputs:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Renovate's nix manager cannot update \`flake.lock\` on Mend-hosted infrastructure (no \`nix\` binary on the sandboxed \`jr-microvm\`, \`allowedCommands\` restricted to \`git add/reset/pwd\`). Every Monday run ends with "Digest is not updated" → level-40 "Error updating branch: update failure".
- Switches to Dependabot's nix ecosystem support (released 2026-04-07) which monitors \`flake.lock\` natively via GitHub Actions — no external nix binary required.
- Groups all nix flake inputs into a single weekly Monday PR via \`groups: nix-flake-inputs\`.
- Part of a coordinated fix across all active hoprnet repos. Pilot: hoprnet/rfc#95.